### PR TITLE
fix for PyMOL 1.7.3+: remove relative pymol.cmd import

### DIFF
--- a/src/main/resources/resources/cmview.py
+++ b/src/main/resources/resources/cmview.py
@@ -8,8 +8,6 @@ from pymol import cmd
 from math import *
 from pymol import string
 
-from cmd import lock,unlock,_cmd # for dist counter
-
 #-------------------------------------------------
 # Create the given file to notify CMView that
 # PyMol is running and receiving commands.


### PR DESCRIPTION
The cmview.py script is executed in the pymol module's namespace. It does a relative import of "cmd" (pymol.cmd), which is no longer possible in PyMOL 1.7.3. Furthermore, this import is actually unused, therefore I propose to remove it (instead of turning it into an absolute import).
